### PR TITLE
Add service editing capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ This API **exposes service installation, modification, and execution via a web i
 
 - List all NSSM-installed services.  
 - Retrieve service details (executable path, startup directory, arguments, and status).  
-- Install a new Windows service using NSSM.  
-- Start and stop NSSM services.  
-- Remove services.  
+- Install a new Windows service using NSSM.
+- Start and stop NSSM services.
+- Remove services.
+- Edit existing services.
 
 ## 🛠 Requirements  
 
@@ -61,6 +62,7 @@ By default, the server runs on `http://127.0.0.1:54321/`.
 |---------|----------------------------------|------------------------------|
 | `GET`   | `/services`                      | List all NSSM-managed services |
 | `POST`  | `/services`                      | Install a new service       |
+| `PATCH` | `/services/{service_name}`       | Edit service settings       |
 | `POST`  | `/services/{service_name}/start` | Start a service             |
 | `POST`  | `/services/{service_name}/stop`  | Stop a service              |
 | `DELETE`| `/services/{service_name}`       | Remove a service            |
@@ -94,10 +96,29 @@ curl -X POST "http://127.0.0.1:54321/services/MyService/start"
 curl -X POST "http://127.0.0.1:54321/services/MyService/stop"
 ```  
 
-#### ✅ Remove a service  
+#### ✅ Remove a service
 ```sh
 curl -X DELETE "http://127.0.0.1:54321/services/MyService"
-```  
+```
+
+#### ✅ Edit an existing service
+```sh
+curl -X PATCH "http://127.0.0.1:54321/services/MyService" \
+-H "Content-Type: application/json" \
+-d '{
+  "executable_path": "C:\\newpath\\app.exe",
+  "startup_directory": "C:\\newpath",
+  "arguments": "--debug"
+}'
+```
+
+### CLI Tool
+
+Run the interactive CLI:
+```sh
+python py_nssm.py
+```
+Choose **"Edit a service"** from the menu and follow the prompts to update an existing service.
 
 ## ⚠️ Notes  
 - This API **requires administrator privileges** to modify services.  

--- a/fastapi_nssm.py
+++ b/fastapi_nssm.py
@@ -24,6 +24,12 @@ class ServiceInstallRequest(BaseModel):
     startup_directory: str
     arguments: Optional[str] = ""
 
+# 📌 Request Model for Updating a Service
+class ServiceUpdateRequest(BaseModel):
+    executable_path: Optional[str] = None
+    startup_directory: Optional[str] = None
+    arguments: Optional[str] = None
+
 # 📌 Helper Function: Remove Null Characters
 def clean_unicode_string(value: str) -> str:
     """Removes null characters and trims whitespace."""
@@ -139,6 +145,33 @@ def install_service(request: ServiceInstallRequest):
         return {"message": f"Service '{request.service_name}' installed successfully."}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error installing service: {str(e)}")
+
+# 📌 API Route: Update an Existing Service
+@app.patch("/services/{service_name}", summary="Update an existing NSSM service")
+def update_service(service_name: str, request: ServiceUpdateRequest):
+    try:
+        # Validate service exists
+        check = subprocess.run(
+            ["nssm", "get", service_name, "Application"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        if check.returncode != 0:
+            raise HTTPException(status_code=404, detail=f"Service '{service_name}' not found")
+
+        if request.executable_path is not None:
+            subprocess.run(["nssm", "set", service_name, "Application", request.executable_path])
+        if request.startup_directory is not None:
+            subprocess.run(["nssm", "set", service_name, "AppDirectory", request.startup_directory])
+        if request.arguments is not None:
+            subprocess.run(["nssm", "set", service_name, "AppParameters", request.arguments])
+
+        return {"service_name": service_name, **get_service_details(service_name)}
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error updating service: {str(e)}")
 
 # 📌 API Route: Start a Service
 @app.post("/services/{service_name}/start", summary="Start a service")

--- a/py_nssm.py
+++ b/py_nssm.py
@@ -122,6 +122,39 @@ def remove_service(service_name):
     except Exception as e:
         print(f"Error removing service '{service_name}': {str(e)}")
 
+def edit_service():
+    """Edit an existing service using nssm.exe."""
+    try:
+        service_name = input("Enter the service name to edit: ").strip()
+        # Validate service exists
+        check = subprocess.run(
+            ["nssm", "get", service_name, "Application"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        if check.returncode != 0:
+            print(f"Service '{service_name}' not found.")
+            return
+
+        new_executable = input("Enter new executable path (leave blank to keep current): ").strip()
+        new_directory = input("Enter new startup directory (leave blank to keep current): ").strip()
+        new_arguments = input("Enter new arguments (leave blank to keep current): ").strip()
+
+        if new_executable:
+            subprocess.run(["nssm", "set", service_name, "Application", new_executable])
+        if new_directory:
+            subprocess.run(["nssm", "set", service_name, "AppDirectory", new_directory])
+        if new_arguments:
+            subprocess.run(["nssm", "set", service_name, "AppParameters", new_arguments])
+
+        details = get_service_details(service_name)
+        print(f"\nUpdated service '{service_name}':")
+        for key, value in details.items():
+            print(f"  {key}: {value}")
+    except Exception as e:
+        print(f"Error editing service '{service_name}': {str(e)}")
+
 def show_menu():
     """Display the menu options."""
     print("\n=====================================")
@@ -132,7 +165,8 @@ def show_menu():
     print("3. Start a service")
     print("4. Stop a service")
     print("5. Remove a service")
-    print("6. Exit")
+    print("6. Edit a service")
+    print("7. Exit")
     print("=====================================")
 
 if __name__ == "__main__":
@@ -164,6 +198,8 @@ if __name__ == "__main__":
                 service_name = input("Enter the service name to remove: ").strip()
                 remove_service(service_name)
             elif choice == "6":
+                edit_service()
+            elif choice == "7":
                 print("Exiting...")
                 break
             else:


### PR DESCRIPTION
## Summary
- allow editing of existing services via new `/services/{service_name}` PATCH endpoint
- add interactive CLI flow for editing service details
- document new API and CLI functionality in README

## Testing
- `python -m py_compile fastapi_nssm.py py_nssm.py`
- `nssm --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad42398c48832cb492be8702073cf0